### PR TITLE
center promo images for widescreens

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
     <!-- Intro Header -->
     <header class="intro">
-		<div id="myCarousel" class="carousel slide" data-ride="carousel">
+		<div id="myCarousel" class="carousel slide" data-ride="carousel" align="center">
 		  <!-- Indicators -->
 		  <ol class="carousel-indicators">
 			<li data-target="#myCarousel" data-slide-to="0" class="active"></li>


### PR DESCRIPTION
![screenshot_20180208_163527](https://user-images.githubusercontent.com/13254332/35981774-64c72506-0cee-11e8-9b0e-cee4cfc541e6.png)
images get centered instead of left-aligned